### PR TITLE
feat(sdr): common header file was made so there are less macros at th…

### DIFF
--- a/sdr/CMakeLists.txt
+++ b/sdr/CMakeLists.txt
@@ -66,9 +66,9 @@ FetchContent_MakeAvailable(googletest)
 
 ### Make the executables #######################################################
 # Radar executable
-add_executable(radar main.cpp rf_settings.cpp rf_settings.hpp utils.cpp utils.hpp pseudorandom_phase.cpp pseudorandom_phase.hpp chirp.hpp chirp.cpp sdr.cpp sdr.hpp)
+add_executable(radar main.cpp rf_settings.cpp rf_settings.hpp utils.cpp utils.hpp pseudorandom_phase.cpp pseudorandom_phase.hpp chirp.hpp chirp.cpp sdr.cpp sdr.hpp common.hpp)
 # Psuedorandom phase noise generation for post-processing
-add_executable(pseudorandom_phase_codes_to_file pseudorandom_phase_to_file.cpp pseudorandom_phase.cpp pseudorandom_phase.hpp)
+add_executable(pseudorandom_phase_codes_to_file pseudorandom_phase_to_file.cpp pseudorandom_phase.cpp pseudorandom_phase.hpp common.hpp)
 
 enable_testing()
 add_subdirectory(${CMAKE_SOURCE_DIR}/../tests ${CMAKE_BINARY_DIR}/tests)

--- a/sdr/chirp.hpp
+++ b/sdr/chirp.hpp
@@ -1,10 +1,7 @@
 #ifndef CHIRP_HPP
 #define CHIRP_HPP
 #include "yaml-cpp/yaml.h"
-#include <iostream>
-#include <cstdint>
-
-using namespace std;
+#include "common.hpp"
 
 class Chirp{
 

--- a/sdr/common.hpp
+++ b/sdr/common.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+#include <boost/format.hpp>
+#include <uhd/usrp/multi_usrp.hpp>
+#include <boost/algorithm/string.hpp>
+#include <iostream>
+#include <random>
+#include <thread>
+#include <boost/filesystem.hpp>
+#include <vector>
+
+using namespace std;
+using namespace uhd;

--- a/sdr/main.cpp
+++ b/sdr/main.cpp
@@ -1,20 +1,15 @@
 #include <uhd/utils/thread.hpp>
 #include <uhd/utils/safe_main.hpp>
-#include <uhd/usrp/multi_usrp.hpp>
 #include <uhd/exception.hpp>
 #include <uhd/types/tune_request.hpp>
 #include <uhd/convert.hpp>
 #include <boost/program_options.hpp>
-#include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <boost/chrono.hpp>
 #include <boost/thread/barrier.hpp>
-#include <boost/algorithm/string.hpp>
-#include <iostream>
 #include <fstream>
 #include <csignal>
 #include <complex>
-#include <thread>
 #include <mutex>
 #include <cstdlib>
 #include <boost/asio/io_service.hpp>
@@ -22,15 +17,12 @@
 #include <boost/asio/write.hpp>
 
 #include "yaml-cpp/yaml.h"
-
 #include "rf_settings.hpp"
 #include "pseudorandom_phase.hpp"
 #include "utils.hpp"
 #include "sdr.hpp"
 #include "chirp.hpp"
-
-using namespace std;
-using namespace uhd;
+#include "common.hpp"
 
 /*
  * PROTOTYPES

--- a/sdr/pseudorandom_phase.hpp
+++ b/sdr/pseudorandom_phase.hpp
@@ -1,9 +1,7 @@
 #ifndef PSEUDORANDOM_PHASE_HPP
 #define PSEUDORANDOM_PHASE_HPP
 
-#include <random>
-
-using namespace std;
+#include "common.hpp"
 
 // Random generators for phaase modulation
 // Seed is identical (and hard-coded) so they will each produce the same sequence

--- a/sdr/rf_settings.hpp
+++ b/sdr/rf_settings.hpp
@@ -3,11 +3,8 @@
 #ifndef RF_SETTINGS_HPP
 #define RF_SETTINGS_HPP
 
-#include <uhd/usrp/multi_usrp.hpp>
+#include "common.hpp"
 #include "yaml-cpp/yaml.h"
-
-using namespace uhd;
-using namespace std;
 
 // Set USRP RF parameters for a single channel of operation
 bool set_rf_params_single(usrp::multi_usrp::sptr usrp, YAML::Node rf0, 

--- a/sdr/sdr.hpp
+++ b/sdr/sdr.hpp
@@ -1,16 +1,9 @@
 #ifndef SDR_HPP
 #define SDR_HPP
-#pragma once
-#include <string>
-#include <cstdint>
-#include "yaml-cpp/yaml.h"
-#include <boost/format.hpp>
-#include <uhd/usrp/multi_usrp.hpp>
-#include <boost/algorithm/string.hpp>
-#include "rf_settings.hpp"
 
-using namespace std;
-using namespace uhd;
+#include "yaml-cpp/yaml.h"
+#include "rf_settings.hpp"
+#include "common.hpp"
 
 class Sdr {
   public:


### PR DESCRIPTION
…e top of all the header file.

common header file includes commonly used macros accros many files so only the common.hpp needs to be included in many. this takes up less space and makes things more concise.